### PR TITLE
Added suppression of US Core deviation

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,3 +1,3 @@
 == Suppressed Messages ==
-# Insurance cards do not require gender in the United States. See US Core ticket FHIR-####.
+# Insurance cards do not require gender in the United States. See US Core ticket FHIR-34240.
 WARNING: StructureDefinition.where(url = 'http://hl7.org/fhir/us/insurance-card/StructureDefinition/C4DIC-Patient').baseDefinition: US FHIR Usage rules require that all profiles on Patient derive from the core US profile

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,2 +1,3 @@
 == Suppressed Messages ==
-# The following code systems are external and not supported by terminology server 
+# Insurance cards do not require gender in the United States. See US Core ticket FHIR-####.
+WARNING: StructureDefinition.where(url = 'http://hl7.org/fhir/us/insurance-card/StructureDefinition/C4DIC-Patient').baseDefinition: US FHIR Usage rules require that all profiles on Patient derive from the core US profile


### PR DESCRIPTION
@cillekisselwatkins this is what needs to be added to suppress the US Core warning.

You'll see that in the commit, in input/ignoreWarnings.txt we must add the JIRA issue tag in the code. I wrote "See US Core ticket FHIR-####". The #### needs our JIRA issue id.

I actually found that the Davinci CRD IG is a good example of how to do this: https://github.com/HL7/davinci-crd/blob/master/input/ignoreWarnings.txt - including the exact text of "See US Core ticket FHIR-####." 

I tested this locally and it works.